### PR TITLE
fix false indention in point cloud filtering

### DIFF
--- a/dataset_pipeline/osdsynth/processor/pointcloud.py
+++ b/dataset_pipeline/osdsynth/processor/pointcloud.py
@@ -115,12 +115,12 @@ class PointCloudReconstruction:
             detections_list[obj_idx]["axis_aligned_bbox"] = axis_aligned_bbox
             detections_list[obj_idx]["oriented_bbox"] = oriented_bbox
 
-            # Filter detections to include only those with a 'pcd' key
-            filtered_detections = [det for det in detections_list if "pcd" in det]
+        # Filter detections to include only those with a 'pcd' key
+        filtered_detections = [det for det in detections_list if "pcd" in det]
 
-            instance_colored_pcds = color_by_instance([det["pcd"] for det in filtered_detections])
-            axis_aligned_bbox = [det["axis_aligned_bbox"] for det in filtered_detections]
-            oriented_bboxes = [det["oriented_bbox"] for det in filtered_detections]
+        instance_colored_pcds = color_by_instance([det["pcd"] for det in filtered_detections])
+        axis_aligned_bbox = [det["axis_aligned_bbox"] for det in filtered_detections]
+        oriented_bboxes = [det["oriented_bbox"] for det in filtered_detections]
 
         if self.vis:
             obj_id = 0

--- a/dataset_pipeline/osdsynth/processor/segment.py
+++ b/dataset_pipeline/osdsynth/processor/segment.py
@@ -59,6 +59,9 @@ class SegmentImage:
         # Tag2Text
         classes = run_tagging_model(self.cfg, img_tagging, self.tagging_model)
 
+        if len(classes) == 0:
+            raise SkipImageException("No foreground objects detected by tagging model.")
+
         # Using GroundingDINO to detect and SAM to segment
         detections = self.grounding_dino_model.predict_with_classes(
             image=image_bgr,  # This function expects a BGR image...


### PR DESCRIPTION
1. Fix indention that leads to unnecessary and repeated filtering.
2. Handle cases where no foreground classes are found by tagging model.